### PR TITLE
NodeBB 0.5.x compatibility - Update to 0.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodebb-plugin-vine",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "NodeBB Vine Plugin",
   "main": "library.js",
   "scripts": {
@@ -9,6 +9,9 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/a5mith/nodebb-plugin-vine"
+  },
+  "nbbpm": {
+    "compatibility": "^0.5.0"
   },
   "keywords": [
     "nodebb",
@@ -27,6 +30,6 @@
   },
   "readme": "",
   "readmeFilename": "README.md",
-  "_id": "nodebb-plugin-vine@0.0.2",
-  "_from": "nodebb-plugin-vine@~0.0.2"
+  "_id": "nodebb-plugin-vine@0.0.3",
+  "_from": "nodebb-plugin-vine@~0.0.3"
 }


### PR DESCRIPTION
New package option in package.json for NodeBB 0.6.0 api breaks.
You need to publish this on npm before 0.6.0 PR
